### PR TITLE
Move away from custom docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://fastapi.tiangolo.com/deployment/docker/
-FROM mikebrady/shairport-sync:5.0.0 AS builder
+FROM mikebrady/shairport-sync:5.0.1 AS builder
 
 RUN apk -U add \
         gettext

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Simple set up, with plans to start using.
 
+Move away from custom docker image ...
+
 Would be cool to add some instructions (someday)
 
 The `shairport-sync.conf` file is located here: https://github.com/mikebrady/shairport-sync/blob/master/scripts/shairport-sync.conf


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the Docker base image version and adds a small README note; no application logic changes.
> 
> **Overview**
> Updates the Docker build to use `mikebrady/shairport-sync:5.0.1` (from `5.0.0`).
> 
> Adds a brief README note indicating an intent to move away from a custom Docker image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2b480b3313ea3dfba33a8fa7c9adee1300a092f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->